### PR TITLE
aux/dbus: fix WifiMode messages being denied by DBus policy

### DIFF
--- a/aux/dbus/org.halium.mechanicd.conf
+++ b/aux/dbus/org.halium.mechanicd.conf
@@ -9,5 +9,7 @@
                send_interface="org.freedesktop.DBus.Introspectable"/>
         <allow send_destination="org.halium.mechanicd"
                send_interface="org.halium.mechanicd.Scheduling"/>
+        <allow send_destination="org.halium.mechanicd"
+               send_interface="org.halium.mechanicd.WifiMode"/>
     </policy>
 </busconfig>


### PR DESCRIPTION
For some reason the policy to allow WifiMode messages to be sent has never been added, so this part of the code has never been called successfully...

This fixes enabling hotspot on devices that requires HAL (and where libwifi-hal.so is still in use...), such as the original Volla Phone.

Bug-UBports: https://gitlab.com/ubports/development/ubuntu-touch/-/issues/2209