### PR TITLE
wifimodeswitch: Support also modern A12/k4.19+ MTK HAL

### DIFF
--- a/src/dbus/wifimodeswitch.cpp
+++ b/src/dbus/wifimodeswitch.cpp
@@ -13,6 +13,8 @@ DBusWifiModeSwitch::DBusWifiModeSwitch(QObject *parent)
     // Only fall back to libhardware_legacy as a last resort.
     wifi_handle = hybris_dlopen("libwifi-hal.so", RTLD_LAZY);
     if (!wifi_handle)
+        wifi_handle = hybris_dlopen("libwifi-hal-mtk.so", RTLD_LAZY);
+    if (!wifi_handle)
         wifi_handle = hybris_dlopen("libhardware_legacy.so", RTLD_LAZY);
 
     if (!wifi_handle)


### PR DESCRIPTION
Android 12+ / kernel v4.19+ modern MediaTek SoCs like MT6768/6789/6877 found on Volla devices do not provide a `libwifi-hal.so` but instead a `libwifi-hal-mtk.so` which provides the same functionality while the current fallback `libhardware_legacy.so` doesn't work.

There still seems to be some weirdness to do with the `wlan1` interface magically becoming permanently managed (despite https://gitlab.com/ubports/porting/reference-device-ports/android11/volla-phone-22/volla-mimameid/-/blob/master/overlay/system/lib/udev/rules.d/99-mtk-wlan1-unmanaged.rules) after toggling hotspot even once *and* rebooting etc. Will see how this behavior seen on 24.04 with this PR fairs to what the status quo is on 20.04 but it's certainly odd..